### PR TITLE
fix: update-packages: rm breaking extension

### DIFF
--- a/packages/eslint-config-typescript/index.js
+++ b/packages/eslint-config-typescript/index.js
@@ -1,6 +1,5 @@
 module.exports = {
     extends: [
-        "prettier/typescript-eslint",
         "eslint-config-prettier",
         "eslint-config-prettier/@typescript-eslint",
         "plugin:@typescript-eslint/eslint-recommended",


### PR DESCRIPTION
Unnecessary to extend prettier/typescript